### PR TITLE
Handle Multiple Documents In a Single Stream/File

### DIFF
--- a/include/yaccety_sax.hrl
+++ b/include/yaccety_sax.hrl
@@ -23,7 +23,8 @@
     proc_inst = true,
     standalone = false,
     namespace_aware = true,
-    external = undefined
+    external = undefined,
+    multiple_documents = false
 }).
 
 -type qname() ::

--- a/src/yaccety_sax.erl
+++ b/src/yaccety_sax.erl
@@ -44,6 +44,8 @@
     | {continuation, {Fun :: fun(), State :: any()}}
     %% External entity reader fun, if any
     | {external, Fun :: fun()}
+    %% Could the stream source contain multiple documents?
+    | {multiple_documents, boolean()}
 ].
 
 -export_type([options/0]).
@@ -89,6 +91,8 @@ opts([{whitespace, Bool} | T], Acc) when is_boolean(Bool) ->
     opts(T, Acc#ys_state{whitespace = Bool});
 opts([{namespace_aware, Bool} | T], Acc) when is_boolean(Bool) ->
     opts(T, Acc#ys_state{namespace_aware = Bool});
+opts([{multiple_documents, Bool} | T], Acc) when is_boolean(Bool) ->
+    opts(T, Acc#ys_state{multiple_documents = Bool});
 opts([], Acc) ->
     Acc;
 opts([H | _], _) ->
@@ -149,6 +153,8 @@ next_event(#ys_state{position = [Position | Ps], rest_stream = Stream} = State) 
                     event_endDocument(State1#ys_state{rest_stream = <<>>});
                 {Event, State1} ->
                     {Event, State1};
+                State1 when State1#ys_state.multiple_documents ->
+                    event_endDocument(State1);
                 State1 ->
                     fatal_error(illegal_data, {Stream, State1})
             end


### PR DESCRIPTION
Goal is to close #8. Solution feels a bit naive, but has worked well locally for our project.
Add option for handling multiple documents, by ending the current document, and retaining rest_stream.